### PR TITLE
Clean up vault contracts

### DIFF
--- a/contracts/vault/UnionPirexStrategy.sol
+++ b/contracts/vault/UnionPirexStrategy.sol
@@ -11,12 +11,12 @@ contract UnionPirexStrategy is UnionPirexStaking {
 
     constructor(
         address _pirexCvx,
-        address _pxCVX,
+        address pxCVX,
         address _distributor,
         address _vault
-    ) UnionPirexStaking(_pxCVX, _distributor, _vault) {
+    ) UnionPirexStaking(pxCVX, _distributor, _vault) {
         if (_pirexCvx == address(0)) revert ZeroAddress();
-        
+
         pirexCvx = PirexCvx(_pirexCvx);
     }
 

--- a/test/PirexCvx-Union.ts
+++ b/test/PirexCvx-Union.ts
@@ -137,9 +137,7 @@ describe('PirexCvx-UnionPirex*', function () {
 
       await expect(
         unionPirex.connect(notAdmin).setWithdrawalPenalty(penalty)
-      ).to.be.revertedWith(
-        `AccessControl: account ${notAdmin.address.toLowerCase()} is missing role ${await unionPirex.DEFAULT_ADMIN_ROLE()}`
-      );
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
     it('Should set withdrawal penalty', async function () {
@@ -156,7 +154,7 @@ describe('PirexCvx-UnionPirex*', function () {
       expect(penaltyAfter).to.equal(penalty);
 
       validateEvent(setEvent, 'WithdrawalPenaltyUpdated(uint256)', {
-        _penalty: penalty,
+        penalty,
       });
     });
   });
@@ -175,9 +173,7 @@ describe('PirexCvx-UnionPirex*', function () {
 
       await expect(
         unionPirex.connect(notAdmin).setPlatform(platform)
-      ).to.be.revertedWith(
-        `AccessControl: account ${notAdmin.address.toLowerCase()} is missing role ${await unionPirex.DEFAULT_ADMIN_ROLE()}`
-      );
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
     it('Should set platform', async function () {
@@ -203,9 +199,7 @@ describe('PirexCvx-UnionPirex*', function () {
 
       await expect(
         unionPirex.connect(notAdmin).setStrategy(strategy)
-      ).to.be.revertedWith(
-        `AccessControl: account ${notAdmin.address.toLowerCase()} is missing role ${await unionPirex.DEFAULT_ADMIN_ROLE()}`
-      );
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
     it('Should revert if strategy is already set', async function () {
@@ -338,8 +332,8 @@ describe('PirexCvx-UnionPirex*', function () {
       });
 
       validateEvent(harvestEvent, 'Harvest(address,uint256)', {
-        _caller: admin.address,
-        _value: rewards,
+        caller: admin.address,
+        value: rewards,
       });
 
       validateEvent(feeTransferEvent, 'Transfer(address,address,uint256)', {
@@ -660,8 +654,8 @@ describe('PirexCvx-UnionPirex*', function () {
       });
 
       validateEvent(harvestEvent, 'Harvest(address,uint256)', {
-        _caller: owner,
-        _value: rewards,
+        caller: owner,
+        value: rewards,
       });
 
       validateEvent(feeTransferEvent, 'Transfer(address,address,uint256)', {


### PR DESCRIPTION
## Changes

UnionPirexVault
- Use Ownable instead of AccessControl (since making use of only 1 role)
- Remove unused ReentrancyGuard inheritance
- Remove unnecessary underscores from variable names
- Add zero address check to `setStrategy`
- Clean up comments
- Update tests

UnionPirexStrategy
- Remove unnecessary underscore from `pxCvx` variable