### PR TITLE
Use AccessControl instead of AccessControlEnumerable

### DIFF
--- a/contracts/tokens/ERC1155PresetMinterSupply.sol
+++ b/contracts/tokens/ERC1155PresetMinterSupply.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.12;
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import {ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
 import {ERC1155Burnable} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
-import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 
 /**
@@ -23,7 +23,7 @@ import {Context} from "@openzeppelin/contracts/utils/Context.sol";
  */
 contract ERC1155PresetMinterSupply is
     Context,
-    AccessControlEnumerable,
+    AccessControl,
     ERC1155Supply,
     ERC1155Burnable
 {
@@ -86,7 +86,7 @@ contract ERC1155PresetMinterSupply is
         public
         view
         virtual
-        override(AccessControlEnumerable, ERC1155)
+        override(AccessControl, ERC1155)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);


### PR DESCRIPTION
## Changes
- Use `AccessControl` instead of `AccessControlEnumerable` since we aren't using role enumeration